### PR TITLE
Fix full-page screenshot bug when given element to blackout

### DIFF
--- a/projects/protractor-screenshot-extension/src/lib/protractor-screenshot-extension.utility.ts
+++ b/projects/protractor-screenshot-extension/src/lib/protractor-screenshot-extension.utility.ts
@@ -120,7 +120,9 @@ export class ProtractorScreenshotExtension {
                     const ignoreLocation = await ignoreElement.getLocation();
                     const ignoreSize = await ignoreElement.getSize();
                     // Adjust coordinates, as the screenshot can be twice the viewport size for high resolution displays.
-                    const parentSize = await parentElement.getSize();
+                    const parentSize = parentElement.driver 
+                        ? await parentElement.driver.manage().window().getSize() 
+                        : await parentElement.getSize();
                     const conversionFactor = imagePng.width / parentSize.width;
                     this._blackoutRectangle(
                         imagePng,


### PR DESCRIPTION
The function `_addBlackoutRectangles` was attempting to call `parentElement.getSize()` regardless of if `parentElement` was an `ElementFinder` or `ProtractorBrowser`, and `ProtractorBrowser` does not have a `.getSize()` method.

Added a check to see if `parentElement` has a `driver` property, and if it does we now call `parentElement.driver.manage().window().getSize()` to get the size of the entire page 